### PR TITLE
changes to remove private key encryption

### DIFF
--- a/lib/ex_auth/helpers/auth_api.ex
+++ b/lib/ex_auth/helpers/auth_api.ex
@@ -186,4 +186,11 @@ defmodule ExAuth.AuthAPI do
       Helpers.headers()
     )
   end
+
+  def login_as_user(user_id) do
+    Helpers.endpoint_get_callback(
+      "#{Helpers.endpoint()}/api/v1/project/#{Helpers.project_id()}/login/#{user_id}",
+      Helpers.headers()
+    )
+  end
 end

--- a/lib/ex_auth/helpers/helpers.ex
+++ b/lib/ex_auth/helpers/helpers.ex
@@ -31,7 +31,7 @@ defmodule ExAuth.Helpers do
   end
 
   def private_key do
-    env(:private_key, %{raise: true}) |> Bcrypt.hash_pwd_salt()
+    env(:private_key, %{raise: true})
   end
 
   def endpoint do

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule ExAuth.MixProject do
       {:httpoison, "~> 1.8"},
       {:poison, ">= 4.0.1"},
       {:phoenix_gen_socket_client, "~> 3.2.2"},
-      {:websocket_client, "~> 1.2"},
+      {:websocket_client, "~> 1.5"},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.10", only: :test}
     ]


### PR DESCRIPTION
As the private key is now returned encrypted directly on Auth, remove encrypting the private key here.